### PR TITLE
Prevent accidental rm -rf /*

### DIFF
--- a/expose.sh
+++ b/expose.sh
@@ -917,7 +917,7 @@ do
 		cd "$topdir"
 	fi
 	
-	rm -rf "$scratchdir"/*
+	rm -rf "${scratchdir:?}/"*
 done
 
 # copy resources to _site


### PR DESCRIPTION
Adds a safer way to do the final rm -rf of the scratch dir.