### PR TITLE
Auto-Orient to enable Exif rotated images to work

### DIFF
--- a/expose.sh
+++ b/expose.sh
@@ -892,7 +892,7 @@ do
 		# only downscale original image
 		if [ "$width" -ge "$res" ]
 		then
-			convert -size "$res"x"$res" "$image" -resize "$res"x"$res" -quality "$jpeg_quality" +profile '*' $options "$topdir/_site/$url/$res.jpg"
+			convert -auto-orient -size "$res"x"$res" "$image" -resize "$res"x"$res" -quality "$jpeg_quality" +profile '*' $options "$topdir/_site/$url/$res.jpg"
 		fi
 	done
 	


### PR DESCRIPTION
I'm seeing failures to display Exif rotations coming through on the web pages. This commit adds a flag that will rotate the images based on the exif data, and fixes the problem. Interestingly the converted images appear correct when viewed alone, but as part of the web page they are not displayed correctly. I've found bugs in Webkit [1] and Mozilla[2] and I think they are ignoring it. It seems Exif rotation is not well supported anyway. [3]

[1] https://bugs.webkit.org/show_bug.cgi?id=19688
[2] https://bugzilla.mozilla.org/show_bug.cgi?id=298619
[3] http://www.daveperrett.com/articles/2012/07/28/exif-orientation-handling-is-a-ghetto/