### PR TITLE
Performance bump by resizing before checking color

### DIFF
--- a/expose.sh
+++ b/expose.sh
@@ -381,7 +381,7 @@ do
 				
 		if [ "$extract_colors" = true ]
 		then
-			palette=$(convert "$image" -depth 4 +dither -colors 7 -unique-colors txt:- | tail -n +2 | awk 'BEGIN{RS=" "} /#/ {print}' 2>&1)
+			palette=$(convert "$image" -resize 200x200 -depth 4 +dither -colors 7 -unique-colors txt:- | tail -n +2 | awk 'BEGIN{RS=" "} /#/ {print}' 2>&1)
 		else
 			palette=""
 			for p in "${default_palette[@]}"


### PR DESCRIPTION
Small change to speed up the script.  If you ask imagemagick to resize the image first, it is significantly quicker when figuring out the color because it has less to process.