### PR TITLE
Added support for project config file

### DIFF
--- a/expose.sh
+++ b/expose.sh
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 
+topdir=$(pwd)
+scriptdir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
 # configuration
+
+# Source configuration file if it exists in the project directory
+if [ -f "$topdir/_config.sh" ]; then
+  . "$topdir/_config.sh"
+fi
 
 site_title=${site_title:-"My Awesome Photos"}
 
@@ -8,7 +16,7 @@ theme_dir=${theme_dir:-"theme1"}
 
 # widths to scale images to (heights are calculated from source images)
 # you might want to change this for example, if your images aren't full screen on the browser side
-resolution=(3840 2560 1920 1280 1024 640)
+resolution=${resolution:-(3840 2560 1920 1280 1024 640)}
 
 # jpeg compression quality for static photos
 jpeg_quality=${jpeg_quality:-92}
@@ -17,15 +25,15 @@ jpeg_quality=${jpeg_quality:-92}
 autorotate=${autorotate:-true}
 
 # formats to encode to, list in order of preference. Available formats are vp9, vp8, h264, h265, ogv
-video_formats=(h264 vp8)
+video_formats=${video_format:-(h264 vp8)}
 
 # video quality - target bitrates in MBit/s matched to each resolution
 # feel free to ignore this if you don't have any videos.
 # the defaults are about 3x vimeo/youtube bitrates to match photographic quality. Personal tolerance to compression artefacts vary, so adjust to taste.
 
-bitrate=(40 24 12 7 4 2)
+bitrate=${bitrate:-(40 24 12 7 4 2)}
 
-bitrate_maxratio=2 # a multiple of target bitrate to get max bitrate for VBR encoding. must be > 1. Higher ratio gives better quality on scenes with lots of movement. Ratio=1 reduces to CBR encoding
+bitrate_maxratio=${bitrate_maxratio:-2} # a multiple of target bitrate to get max bitrate for VBR encoding. must be > 1. Higher ratio gives better quality on scenes with lots of movement. Ratio=1 reduces to CBR encoding
 
 disable_audio=${disable_audio:-true}
 
@@ -36,7 +44,7 @@ backgroundcolor=${backgroundcolor:-"#000000"} # slide background, visible only b
 textcolor=${textcolor:-"#ffffff"} # default text color
 
 # palette of 7 colors, background to foreground, to be used if color extraction is disabled
-default_palette=("#000000" "#222222" "#444444" "#666666" "#999999" "#cccccc" "#ffffff")
+default_palette=${default_palette:-("#000000" "#222222" "#444444" "#666666" "#999999" "#cccccc" "#ffffff")}
 
 override_textcolor=${override_textcolor:-true} # use given text color instead of extracted palette on body text.
 
@@ -53,10 +61,10 @@ download_readme=${download_readme:-"All rights reserved"}
 disqus_shortname=${disqus_shortname:-""}
 
 # arbitrary list of extensions we'll assume are video files.
-video_extensions=(3g2 3gp 3gp2 asf avi dvr-ms exr ffindex ffpreset flv gxf h261 h263 h264 h265 ifv m2t m2ts mts m4v mkv mod mov mp4 mpg mxf tod vob webm wmv y4m)
+video_extensions=${video_extensions:-(3g2 3gp 3gp2 asf avi dvr-ms exr ffindex ffpreset flv gxf h261 h263 h264 h265 ifv m2t m2ts mts m4v mkv mod mov mp4 mpg mxf tod vob webm wmv y4m)}
 
-sequence_keyword="imagesequence" # if a directory name contains this keyword, treat it as an image sequence and compile it into a video
-sequence_framerate=24 # sequence framerate
+sequence_keyword=${sequence_keyword:-"imagesequence"} # if a directory name contains this keyword, treat it as an image sequence and compile it into a video
+sequence_framerate=${sequence_framerate:-24} # sequence framerat
 
 # specific codec options here
 h264_encodespeed=${h264_encodespeed:-"veryslow"} # h264 encode speed, slower produces better compression results. Options are ultrafast,superfast, veryfast, faster, fast, medium, slow, slower, veryslow
@@ -71,9 +79,6 @@ command -v identify >/dev/null 2>&1 || { echo "ImageMagick is a required depende
 
 # file extensions for each video format
 video_format_extensions=("h264" "mp4" "h265" "mp4" "vp9" "webm" "vp8" "webm" "ogv" "ogv")
-
-topdir=$(pwd)
-scriptdir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 draft=false
 # the -d flag has been set

--- a/readme.md
+++ b/readme.md
@@ -18,8 +18,8 @@ tested on Windows/Cygwin, OSX, and should be fine on Linux
 
 The only dependency is Imagemagick. For videos FFmpeg is also required.
 
-download the repo and alias the script
-	
+Download the repo and alias the script
+
 	alias expose=/script/location/expose.sh
 
 for permanent use add this line to your ~/.profiles, ~/.bashrc etc depending on system
@@ -30,7 +30,22 @@ for permanent use add this line to your ~/.profiles, ~/.bashrc etc depending on 
 	expose
 
 The script operates on your current working directory, and outputs a _site directory.
-Configuration and settings can be edited in the expose.sh file itself
+
+### Configuration
+
+Configuration values and settings can be set by creating `_config.sh` in the top
+level of your project. This allows you to keep a single install of Expose with
+different settings for projects. This will also keep your custom settings safe
+when upgrading Expose.
+
+#### Example
+
+```sh
+site_title="Alternate Site Title"
+theme_dir="theme2"
+social_button=false
+backgroundcolor="#ffffff"
+```
 
 ### Flags
 
@@ -110,11 +125,11 @@ CSS classes can be passed to the template via the "class" property. eg: use `cla
 ### Metadata file
 
 If you want certain variables to apply to an entire gallery, place a metadata.txt (this is configurable) file in the gallery directory. eg. in metadata.txt:
-	
-	width: 19	
+
+	width: 19
 
 ![image grid](http://jack.works/exposeimages/grid.jpg)
-	
+
 This sets all image widths to form a grid. Metadata file parameters are overriden by metadata in individual posts.
 
 ### Advanced usage
@@ -126,13 +141,13 @@ Since we're using FFMpeg for video, we can leverage its filter framework for qui
 	---
 	video-options: -ss 10 -t 5
 	---
-	
+
 This will cut the video 10 seconds from the start, with a duration of 5 seconds.
 
 	---
 	video-filters: lut3d=file=fuji3510.cube
 	---
-	
+
 If you're like me and shoot video in log profile, doing post work can be a pain. I like to globally apply a [film print emulation LUT](http://juanmelara.com.au/print-film-emulation-luts-for-download/) for a consistent look. Note that FFmpeg will look for the LUT file in the working directory you started the script in.
 FFmpeg does not support .look LUTs, so you'll have to convert them to one of .cube .3dl .dat or .m3d
 
@@ -155,7 +170,7 @@ Similar to videos, we can leverage the image editing features of Imagemagick.
 Things like cropping and color correction are very visual operations that are hard to do in command line. Most people would shoot in RAW and export as jpeg anyways, so a lot of ImageMagick's CLI options won't be very useful. However, it is very handy for non-destructively applying effects across an entire gallery, eg:
 
 	---
-	image-options: watermark.png -gravity SouthEast -geometry +50+50 -composite 
+	image-options: watermark.png -gravity SouthEast -geometry +50+50 -composite
 	---
 
 You can use this to apply a watermark on the bottom right corner, with a 50 pixel margin from the edge.
@@ -228,7 +243,7 @@ this will cause {{mycustomvar}} to be replaced by "foo", in this particular post
 #### Additional notes:
 
 Specify default values, in case of unset template variables in the form {{foo:bar}} eg:
-	
+
 	{{width:50}}
 
 will set width to 50 if no specific value has been assigned to it by the time page generation has finished.


### PR DESCRIPTION
Instead of editing settings within `expose.sh` or passing them through the command line, this PR adds support for reading `_config.sh` in the project's working directory for settings. If a value isn't found, Expose sets the default like usual.

If a lot of customization is done, it can be troublesome to set all setting through the command line as added in 39db4c0e80a78106aa238bf668686c1b308f6c0f. The use of a config file allows for these settings to be easily stored per project and read automatically if the file exists.

I added configuration information to the README as well since, upon initially looking at Expose, it was not obvious how to set things like site title.

Though a number of variables support being set externally, not all were. I went through and made all configuration settings externally editable, either through command line or this config file.
